### PR TITLE
bootstrap tweaks

### DIFF
--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -50,7 +50,7 @@ public class MaxwellConfig {
 
 
 	public String getConnectionURI() {
-		return "jdbc:mysql://" + mysqlHost + ":" + mysqlPort;
+		return "jdbc:mysql://" + mysqlHost + ":" + mysqlPort + "?" + "useCursorFetch=true";
 	}
 
 	private OptionParser getOptionParser() {

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -81,7 +81,10 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 						table.getPKList(),
 						position);
 				setRowValues(row, resultSet, table);
-				LOGGER.debug("bootstrapping row : " + row.toJSON());
+
+				if ( LOGGER.isDebugEnabled() )
+					LOGGER.debug("bootstrapping row : " + row.toJSON());
+
 				producer.push(row);
 				++insertedRows;
 				updateInsertedRowsColumn(insertedRows, startBootstrapRow, position, connection);

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -209,7 +209,11 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 		int columnIndex = 1;
 		while ( columnDefinitions.hasNext() ) {
 			ColumnDef columnDefinition = columnDefinitions.next();
-			row.putData(columnDefinition.getName(), columnDefinition.asJSON(resultSet.getObject(columnIndex)));
+			Object columnValue = resultSet.getObject(columnIndex);
+
+			if ( columnValue != null )
+				row.putData(columnDefinition.getName(), columnDefinition.asJSON(columnValue));
+
 			++columnIndex;
 		}
 	}


### PR DESCRIPTION
- useCursorFetch=true enables memory-friendly behavior for real
- protect against an extra `.toJSON`
- avoid passing NULLs into ColumnDefinition.to_json
